### PR TITLE
feat：添加revision选项，revise命令与revision环境，适用于修改稿中令修改部分标红

### DIFF
--- a/DissertUESTC.cls
+++ b/DissertUESTC.cls
@@ -124,6 +124,9 @@
 \newboolean{reviewflag}
 \setboolean{reviewflag}{false}
 
+\newboolean{revisionflag}
+\setboolean{revisionflag}{false}
+
 %% 用来控制是否打印违反规范时的提醒信息
 \newboolean{usereminder}
 \setboolean{usereminder}{true}
@@ -298,6 +301,23 @@
 }
 
 
+\newcommand{\revise}[1]{%
+	\ifthenelse{\boolean{revisionflag}}%
+		{\textcolor{red}{#1}}%
+		{#1}%
+}
+
+
+
+\newenvironment{revision}{%
+	\ifthenelse{\boolean{revisionflag}}%
+		{\begingroup\color{red}}%
+		{\begingroup}%
+}{%
+	\endgroup%
+}
+
+
 \newcommand{\uestcheavyrulewidth}{1.5bp}  % 用于设置\toprule、\bottomrule默认线粗，本科0.5bp，研究生1.5bp
 \newcommand{\uestclightrulewidth}{0.75bp}  % 用于设置\midrule默认线粗，本科0.5bp，研究生0.75bp
 
@@ -316,6 +336,10 @@
 
 \DeclareOption{review}{%
 	\setboolean{reviewflag}{true}%
+}%
+
+\DeclareOption{revision}{%
+	\setboolean{revisionflag}{true}%
 }%
 
 \DeclareOption{print}{

--- a/readme.md
+++ b/readme.md
@@ -181,7 +181,7 @@
 模板的导言区只有两行：
 1. `% !TEX Program = xelatex`在TeXstudio编辑器中表示指定使用`XeLaTeX`引擎编译该文档，对其他编辑器，可能需要手动设置编译引擎。
 
-2. `\documentclass[<选项列表>]{DissertUESTC}`表示加载名为`DissertUESTC`的文档类，该文档类基于LaTeX的`book`类编写。此文档类可设置**八种**选项：
+2. `\documentclass[<选项列表>]{DissertUESTC}`表示加载名为`DissertUESTC`的文档类，该文档类基于LaTeX的`book`类编写。此文档类可设置**九种**选项：
 
    1. `print`/`nonprint`：该选项控制是否以印刷模式生成文档，印刷模式会自动在论文的前置部分添加必要的空白页，默认为`nonprint`。
 
@@ -218,6 +218,8 @@
       :four_leaf_clover: 其实，规范并未对公式字体作强制要求，即便审查系统识别到公式字体不是Times New Roman，它也只是抛出提醒而非错误，不会造成格式审查不通过。只是实在有太多人问怎么公式字体不是Times New Roman，既然有部分同学喜欢Times New Roman，那本模板秉承兼容并包的原则，将选择权交给使用者。
 
    8. 另外，[algorithm2e](https://mirrors.sustech.edu.cn/CTAN/macros/latex/contrib/algorithm2e/doc/algorithm2e.pdf)宏包的`vlined`和`boxruled`选项也可以在加载文档类时设置。
+
+   9. [**新增**]`revision`：该选项用于排版评审意见返回后的论文修改标注稿。启用该选项后，置于`\revise{<修改内容>}`命令中的行内内容，以及置于`revision`环境中的段落、节、公式等块级内容，将以红色显示；未启用该选项时，上述内容将保持正常排版。图题、表题、算法、交叉引用等内容不能通过此方式标红。该选项独立于用于盲审匿名化处理的`review`选项，适合在保留作者、导师等正常论文信息的同时标出修改内容。
 
 ## 3. 论文封面及扉页
 

--- a/tutorial.tex
+++ b/tutorial.tex
@@ -520,7 +520,7 @@
 	\begin{itemize}
 		\item \shad{\% !TEX Program = xelatex}：在Texstudio中，这表示指定使用\shad{XeLaTeX}引擎编译该文档；在其他编辑器中，需要手动设置编译引擎为\shad{XeLaTeX}。
 
-		\item \shadcmd{documentclass[<选项列表>]\{DissertUESTC\}}：加载名为\shad{DissertUESTC} 的文档类，该文档类基于LaTeX的\shad{book}类编写，可设置\textbf{\textcolor{DarkRed}{八种}}选项：
+		\item \shadcmd{documentclass[<选项列表>]\{DissertUESTC\}}：加载名为\shad{DissertUESTC} 的文档类，该文档类基于LaTeX的\shad{book}类编写，可设置\textbf{\textcolor{DarkRed}{九种}}选项：
 
 		\begin{itemize}
 			\item \shad{print} / \shad{nonprint}\textcolor{DarkRed}{〔默认〕}：该选项控制是否以印刷模式生成文档，印刷模式会按印刷要求自动在论文的前置部分添加必要的空白页。
@@ -557,6 +557,15 @@
 			另外，\textcolor{DarkRed}{模板支持将\shad{review}的作用范围扩展到其他内容}。例如，送审前需要抹除“致谢”和“成果”中的个人身份信息，使用者可将相应内容置于\shadcmd{ifreview[<替换文本>]\{<原内容>\}}命令。若未指定该命令的第一项可选参数，\shad{review}选项将以两字宽的水平空白替换原内容；否则，\shad{review}选项将以指定的参数替换原内容。用户可对比以下两句话在\shad{review}选项下的区别。（2025.03.06）
 
 			\textbf{示例}：杨过的师傅是\ifreview[XXX]{小龙女}；杨过不承认师傅是\ifreview{赵志敬}。
+
+			\item \shad{revision}：该选项用于排版评审意见返回后的论文修改标注稿。启用该选项后，置于`\shadcmd{ifreview\{<修改内容>\}}`命令中的行内内容，以及置于\shad{revision}环境中的段落、节、公式等块级内容，将以红色显示；未启用该选项时，上述内容将保持正常排版。图题、表题、算法、交叉引用等内容不能通过此方式标红。该选项独立于用于盲审匿名化处理的\shad{review}选项，适合在保留作者、导师等正常论文信息的同时标出修改内容。用户可对比以下文字与公式在\shad{revision}选项下的区别。（2026.05.13）
+
+            \textbf{示例}：
+            
+			\begin{revision}
+                杨过与小龙女重逢后，心情喜悦，掌法威力有限；后来陷入生死关头，想到要与小龙女永诀，哀痛欲绝，威力才重新出现。
+                \[\text{战斗力}_{黯然销魂掌} \sim  e^{相思之苦}\]
+            \end{revision}
 			
 			\item \shad{noreminder}：默认情况下，当\textbf{“中文摘要”}和\textbf{“致谢”}的篇幅超出规范的最大页数限制时，模板（\textbf{经过两次编译后}）将在对应内容的结尾显式打印提醒信息。若使用者在知悉这些内容的长度超出规范限制后仍希望保持原样，则可使用\shad{noreminder}选项禁用提醒信息。（2025.02.22）
 			


### PR DESCRIPTION
由于学位论文根据评阅意见修改时，需要将修改版论文中的修改之处全部标红。模板还没有这个功能，故添加revision选项，revise命令与revision环境。revision选项用于是否开启标红，revise命令用于将较短文字标红，revision环境用于将大范围段落统一标红，此方法不支持将revision环境中图题、表题、交叉引用、算法等内容的标红。